### PR TITLE
Fix code scanning alert no. 9: Log entries created from user input

### DIFF
--- a/Curupira.Plugins.Common/NLogProvider.cs
+++ b/Curupira.Plugins.Common/NLogProvider.cs
@@ -30,15 +30,15 @@ namespace Curupira.Plugins.Common
             Log = logger;
         }
 
-        public virtual void Trace(string message, params object[] args) => Log.Trace(message, args);
+        public virtual void Trace(string message, params object[] args) => Log.Trace(SanitizeMessage(message), args);
 
-        public virtual void Debug(string message, params object[] args) => Log.Debug(message, args);
+        public virtual void Debug(string message, params object[] args) => Log.Debug(SanitizeMessage(message), args);
 
-        public virtual void Info(string message, params object[] args) => Log.Info(message, args);
+        public virtual void Info(string message, params object[] args) => Log.Info(SanitizeMessage(message), args);
 
-        public virtual void Warn(string message, params object[] args) => Log.Warn(message, args);
+        public virtual void Warn(string message, params object[] args) => Log.Warn(SanitizeMessage(message), args);
 
-        public virtual void Fatal(string message, params object[] args) => Log.Fatal(message, args);
+        public virtual void Fatal(string message, params object[] args) => Log.Fatal(SanitizeMessage(message), args);
 
         public virtual void Fatal(Exception exception, string message = null, params object[] args)
         {
@@ -52,7 +52,7 @@ namespace Curupira.Plugins.Common
             }
         }
 
-        public virtual void Error(string message, params object[] args) => Log.Error(message, args);
+        public virtual void Error(string message, params object[] args) => Log.Error(SanitizeMessage(message), args);
 
         public virtual void Error(Exception exception, string message = null, params object[] args)
         {
@@ -129,6 +129,11 @@ namespace Curupira.Plugins.Common
             {
                 sb.Length -= 2;
             }
+        }
+
+        private string SanitizeMessage(string message)
+        {
+            return message?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/tiglate/Curupira/security/code-scanning/9](https://github.com/tiglate/Curupira/security/code-scanning/9)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the user input to prevent log forgery. This can be done by replacing newline characters with an empty string. We will apply this sanitization in the `NLogProvider` class before logging any messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
